### PR TITLE
Fix typo in Composer install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ wp plugin install --activate acf-openstreetmap-field
 
 #### Using Composer
 ```shell
-wp plugin install --activate acf-openstreetmap-field
+composer require mcguffin/acf-quickedit-fields
 ```
 
 ### Development


### PR DESCRIPTION
Looks like a copy & paste error 😌