### PR TITLE
Patch 1

### DIFF
--- a/src/js/lib/fields/post_object.js
+++ b/src/js/lib/fields/post_object.js
@@ -3,9 +3,33 @@ import $ from 'jquery';
 module.exports = {
 	type:'post_object',
 	initialize:function() {
-		this.parent().initialize.apply(this,arguments);
 
 		this.$input = this.$('select').prop( 'readonly', true );
+
+		this.parent().initialize.apply(this,arguments);
+
+		if( typeof acf !== 'object' ) {
+			return;
+		}
+		var self = this;
+
+		// init select2
+		this.$input.select2();		// 2DO: not really needed, but helps in showing placeholder text on init
+
+		// 2DO: workaround 'acf/fields/undefined/query' ajax action, but why?
+		acf.add_filter('select2_ajax_data', function( data, args, $input, $field ){
+			if( data.field_key !== self.key ) {
+				return data;
+			}
+			
+			let type = args.field.data.fieldType;
+			if( typeof type !== 'undefined' ) {
+				data.action = 'acf/fields/'+type+'/query';
+			}
+			
+			return data;	
+		});
+
 	},
 	setValue:function(value) {
 		// the value has been loded by an ajax request
@@ -17,7 +41,17 @@ module.exports = {
 		We'll have to fetch the corresponding post titles as well and append selected <option>s to this.$input
 		*/
 
-		this.$input.val(value);
+		var self = this;
+		if( _.isArray(value) ) {
+			_.each(value, function(val) {
+				self.$input.append( new Option(val.text, val.id, true, true) ).trigger('change');
+			});
+		} else if( _.isObject(value) ) {
+			// set current default value by appending a selected option element
+			self.$input.append( new Option(value.text, value.id, true, true) ).trigger('change');
+		}
+
 		return this;
 	}
 }
+


### PR DESCRIPTION
hey,

thanks for the starting point and the easy local dev setup experience :)

I managed to make it work now. Yay! 
There are some lines in the code that might need review, expecially the value sanitization. For now I just rigourously bypassed this which is not ideal but given the custom data structure needed for select2, I didn't come up with a quick fix for this, I'm sorry. We might need to build a somewhat custom data parsing logic here.

I'm also scratching my head on the 'undefined' data request route that the select2 acf field has per default and wrote a simple workaround using the select2-args filter. you might know better why this is the case here.

I'd be happy if my proposal is of any help and if you'd use my changes to implement the post_object support in your plugin.

cheers!