### PR TITLE
Suggested change to supporthook for capability

### DIFF
--- a/include/ACFQuickEdit/Admin/Admin.php
+++ b/include/ACFQuickEdit/Admin/Admin.php
@@ -87,7 +87,7 @@ class Admin extends Core\Singleton {
 		$this->ajax_handler = new Ajax\AjaxHandler( 'get_acf_post_meta', [
 			'public'			=> false,
 			'use_nonce'			=> true,
-			'capability'		=> 'edit_posts',
+			'capability'		=> apply_filters( 'acf_qef_capability', 'edit_posts' ),
 			'callback'			=> [ $this, 'ajax_get_acf_post_meta' ],
 			'sanitize_callback'	=> [ $this, 'sanitize_ajax_get_acf_post_meta' ],
 		]);


### PR DESCRIPTION
Wrapping the default capability edit_posts with: apply_filters( 'acf_qef_capability', 'edit_posts' ) in order to provide support for more granular user roles/capabilities.

i have it on a specific site, it is the thing that you always forget when you update the plugin, that will be great if you include it on future versions