### PR TITLE
update composer package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ wp plugin install --activate acf-quickedit-fields
 
 #### Using Composer
 ```shell
-composer require mcguffin/acf-quickedit-fields
+composer require mcguffin/acf-quick-edit-fields
 ```
 
 ### Development

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mcguffin/acf-quickedit-fields",
+	"name": "mcguffin/acf-quick-edit-fields",
 	"description": "WordPress Plugin implementing Column Displaying, QuickEdit and BulkEdit for Advanced Custom Fields (ACF)",
 	"license": "GPL-3.0-or-later",
 	"type": "wordpress-plugin",
@@ -27,6 +27,9 @@
 		"post-update-cmd": [
 			"[ -f vendor/bin/phpcs ] && \"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs,vendor/pheromone/phpcs-security-audit || true"
 		]
+	},
+	"extra": {
+		"installer-name": "acf-quickedit-fields"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
The documented composer command did not work; it returned this error:

```
[InvalidArgumentException]
Could not find a matching version of package mcguffin/acf-quickedit-fields. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability (dev).                                                                                                                                                                                                                           
```

This PR:

1. Updates the docs to match the [actual package name](https://packagist.org/packages/mcguffin/acf-quick-edit-fields)
1. Sets a custom installation path to match the new slug

Alternative to this PR: update the package name and republish on packagist