### PR TITLE
Fix: undefined array key parent

### DIFF
--- a/include/ACFQuickEdit/Fields/Field.php
+++ b/include/ACFQuickEdit/Fields/Field.php
@@ -155,14 +155,15 @@ abstract class Field {
 
 		$parent_key	= '';
 
-
-		if ( is_numeric( $this->acf_field['parent'] ) ) {
-			// int: field stored in DB
-			$parent = get_post( $this->acf_field['parent'] );
-			$parent_key = $parent->post_name;
-		} else {
-			// local json field
-			$parent_key = $this->acf_field['parent'];
+		if ( !empty( $this->acf_field['parent'] ) ) {
+			if ( is_numeric( $this->acf_field['parent'] ) ) {
+				// int: field stored in DB
+				$parent = get_post( $this->acf_field['parent'] );
+				$parent_key = $parent->post_name;
+			} else {
+				// local json field
+				$parent_key = $this->acf_field['parent'];
+			}
 		}
 
 		if (  'field_' === substr( $parent_key, 0, 6 ) ) {


### PR DESCRIPTION
After a fresh install and activation of this plugin, my ACF page immediately crashes when I want to edit an ACF field.

I added a conditional that prevents this crash, making the plugin usable again for me. Thank you for your contribution!