### PR TITLE
Fix: fix column sort by multiple keys

### DIFF
--- a/include/ACFQuickEdit/Admin/Columns.php
+++ b/include/ACFQuickEdit/Admin/Columns.php
@@ -298,9 +298,11 @@ class Columns extends Feature {
 
 		$meta_query = parent::get_meta_query( $wp_query );
 
-		if ( ! isset( $wp_query->query_vars['orderby'] ) || !( $by = $wp_query->query_vars['orderby']) ) {
+		if ( ! isset( $wp_query->query_vars['orderby'] ) || !( $by = $wp_query->query_vars['orderby']) ||
+			is_array( $by ) ) {
 			return $meta_query;
 		}
+
 		if ( ! isset( $this->fields[ $by ] ) ) {
 			return $meta_query;
 		}


### PR DESCRIPTION
If the 'order_by' query var contains an array, columns sort will break. This just catches this case instead of failing and does nothing as sorting by multiple keys is not yet supported by this plugin.