### PR TITLE
PostObject get_value changed from object to array

### DIFF
--- a/include/ACFQuickEdit/Fields/Traits/ColumnLists.php
+++ b/include/ACFQuickEdit/Fields/Traits/ColumnLists.php
@@ -14,8 +14,8 @@ trait ColumnLists {
 		}
 
 		$value = $this->get_value( $object_id, false );
-		if ( is_object( $value ) && isset( $value->id ) ) {
-			$value = $value->id;
+		if ( is_array( $value ) && isset( $value['id'] ) ) {
+			$value = $value['id'];
 		}
 		$value = (array) $value;
 		$value = array_filter( $value );


### PR DESCRIPTION
In this commit https://github.com/mcguffin/acf-quickedit-fields/commit/ba70ca5726508f5ab83601c3e22c4d2fa6e204bf a custom `get_value` function was created for PostObjects and an exception was added to `render_list_column` to accomodate the return value.  However,  when the return value was changed from an object to an array, the accomodation wasn't adjusted (https://github.com/mcguffin/acf-quickedit-fields/commit/e42f11478c6aefa54c7b2adbd74260fd39440afd), leading to the problem seen here https://github.com/mcguffin/acf-quickedit-fields/issues/147.