### PR TITLE
Update logic when multiple is false and ui is 1

### DIFF
--- a/include/ACFQuickEdit/Fields/Traits/InputSelect.php
+++ b/include/ACFQuickEdit/Fields/Traits/InputSelect.php
@@ -37,11 +37,12 @@ trait InputSelect {
 		if ( $acf_field['multiple'] ) {
 			$input_atts['multiple'] = 'multiple';
 			$input_atts['name']	.= '[]';
-			if ( $acf_field['ui'] ) {
-				$input_atts['class'] .= ' ui';
-				$input_atts['data-nonce'] = wp_create_nonce( $acf_field['key'] );
-				$input_atts['data-query-nonce'] = wp_create_nonce( $acf_field['key'] ); // backwards compatibility ACF < 6.3.1
-			}
+		}
+		
+		if ( $acf_field['ui'] ) {
+			$input_atts['class'] .= ' ui';
+			$input_atts['data-nonce'] = wp_create_nonce( $acf_field['key'] );
+			$input_atts['data-query-nonce'] = wp_create_nonce( $acf_field['key'] ); // backwards compatibility ACF < 6.3.1
 		}
 
 		$output .= sprintf( '<select %s>', acf_esc_attr( $input_atts ) ) . PHP_EOL;


### PR DESCRIPTION
This further updates #167 and should address #177. Given a field like this:

```php
$acf_field['multiple'] = false;
$acf_field['ui'] = 1;
```

Then the proper nonces were not being set and the values would fail to load in the bulk editor. This updates the `ui` attributes even if multiple is false.

Props to @fionchadd for this fix.